### PR TITLE
Fix quickstart_tensorflow for macos

### DIFF
--- a/examples/quickstart_tensorflow/pyproject.toml
+++ b/examples/quickstart_tensorflow/pyproject.toml
@@ -9,7 +9,8 @@ description = "Keras Federated Learning Quickstart with Flower"
 authors = ["The Flower Authors <hello@flower.dev>"]
 
 [tool.poetry.dependencies]
-python = ">=3.7,<3.11"
+python = ">=3.8,<3.11"
 flwr = "^1.0.0"
 tensorflow-cpu = { version = "^2.9.1", markers = "sys_platform != 'darwin'" }
 tensorflow-macos = { version = "^2.9.1", markers = "sys_platform == 'darwin'" }
+numpy = "^1.22.0"

--- a/examples/quickstart_tensorflow/pyproject.toml
+++ b/examples/quickstart_tensorflow/pyproject.toml
@@ -11,4 +11,5 @@ authors = ["The Flower Authors <hello@flower.dev>"]
 [tool.poetry.dependencies]
 python = ">=3.7,<3.11"
 flwr = "^1.0.0"
-tensorflow-cpu = "^2.9.1"
+tensorflow-cpu = { version = "^2.9.1", markers = "sys_platform != 'darwin'" }
+tensorflow-macos = { version = "^2.9.1", markers = "sys_platform == 'darwin'" }


### PR DESCRIPTION
Changes:

- use tensorflow-macos intead of tensorflow-cpu on macos using poetry conditional install
- upgrade numpy version to fix runtime error

---

memo:

```zsh
export GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1
export GRPC_PYTHON_BUILD_SYSTEM_ZLIB=1
poetry install
poetry run python -c 'import tensorflow' # check no error
```