### PR TITLE
[examples/quickstart_tensorflow] Use tensorflow-aarch64 instead of tensorflow-cpu for linux arm64

### DIFF
--- a/examples/quickstart_tensorflow/pyproject.toml
+++ b/examples/quickstart_tensorflow/pyproject.toml
@@ -12,6 +12,7 @@ authors = ["The Flower Authors <hello@flower.dev>"]
 python = ">=3.8,<3.11"
 # flwr = "^1.0.0"
 flwr = { path = "../../", develop = true }
-tensorflow-cpu = { version = "^2.9.1", markers = "sys_platform != 'darwin'" }
+tensorflow-cpu = { version = "^2.9.1", markers = "sys_platform != 'darwin' and platform_machine == 'x86_64'" }
+tensorflow-aarch64 = { version = "^2.9.1", markers = "sys_platform != 'darwin' and platform_machine != 'x86_64'" }
 tensorflow-macos = { version = "^2.9.1", markers = "sys_platform == 'darwin'" }
 numpy = "^1.22.0"


### PR DESCRIPTION
Changes:

- use tensorflow-aarch64 instead of tensorflow-cpu for linux arm64
	- error on docker linux/arm64:
		```
		RuntimeError
		Unable to find installation candidates for tensorflow-cpu (2.10.0)
		```